### PR TITLE
fix: Make webpack config work for server-side rendering

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ const prodConfig = {
     library: 'rrNotifications',
     libraryTarget: 'umd',
     umdNamedDefine: true,
+    globalObject: 'this',
   },
   module: {
     rules: [


### PR DESCRIPTION
I added what webpack claims will make this work both client- and server-side. But beware: I haven't tested this and don't know how to test it, so you might want to test it first or tell me how to.